### PR TITLE
Added create project if Space/Project provided in Github Action

### DIFF
--- a/steps.ps1
+++ b/steps.ps1
@@ -49,7 +49,7 @@ if (Test-Path -Path $octoYamlPath -PathType Leaf)
   {
     throw "Project Name not provided"
   }
-  
+
   $requestHeaders = New-Object System.Collections.Generic.Dictionary"[String,Object]"
   $requestHeaders.Add("x-api-key",$env:LAZY_API_KEY)
 


### PR DESCRIPTION
# Description

Added ability to create project if not exist if Space/Project provided only in GitHub workflow yaml

Fixes [#45](https://usxtech.atlassian.net/browse/CLOUD-45)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To test this PR, use this dummy repository to edit the GitHub workflow yaml file as described in the documentation. 
- Workflow file path: github/workflows/build-octo-push.yaml
The action should successfully create a project if it doesn't exist, configure the deployment process and create a release.

https://github.com/variant-inc/this-is-not-a-test/blob/salyateem13-patch-4/.github/workflows/build-octo-push.yaml

- [ ] Unit Tests
- [x] Sanity Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
