### PR TITLE
Update release.ps1

### DIFF
--- a/release.ps1
+++ b/release.ps1
@@ -69,7 +69,7 @@ $jsonBody = @{
   )
 } | ConvertTo-Json -Depth 10 -Compress
 
-New-Item "buildinformation.json" -ItemType File
+New-Item "buildinformation.json" -ItemType File -Force
 Set-Content -Path "buildinformation.json" -Value $jsonBody
 
 Write-Output "Pushing Build Information"


### PR DESCRIPTION
# Description
Ability to overwrite buildinformation.json file

# Summary
This change provides the ability to rewrite buildinformation.json file when there are two Lazy Action Octopus steps in the same octo-push.yaml file being pushed to two separate octopus projects
Fix addresses the issue - https://github.com/variant-inc/schedule-adherence/runs/2972400617?check_suite_focus=true

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Tested it with the branch - https://github.com/variant-inc/schedule-adherence/blob/f/SA-595-tripvalidationhandler-deployment/.github/workflows/octo-push.yaml
Successful  run https://github.com/variant-inc/schedule-adherence/actions/runs/993992208

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
