### PR TITLE
test path

### DIFF
--- a/tasks.ps1
+++ b/tasks.ps1
@@ -11,21 +11,18 @@ $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 $WarningPreference = "SilentlyContinue"
 
-Trap
-{
+Trap {
   Write-Error $_.InvocationInfo.ScriptName -ErrorAction Continue
   $line = "$($_.InvocationInfo.ScriptLineNumber): $($_.InvocationInfo.Line)"
   Write-Error $line -ErrorAction Continue
   Write-Error $_
 }
-function CommandAliasFunction
-{
+function CommandAliasFunction {
   Write-Information ""
   Write-Information "$args"
   $cmd, $args = $args
   & "$cmd" $args
-  if ($LASTEXITCODE)
-  {
+  if ($LASTEXITCODE) {
     throw "Exception Occured"
   }
   Write-Information ""
@@ -35,9 +32,16 @@ Set-Alias -Name ce -Value CommandAliasFunction -Scope script
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Scope = 'Function')]
 $variantApiDeployYamlPath = [System.IO.Path]::GetFullPath((Join-Path ${RepositoryRoot} ".variant/deploy/"))
-$deployYamlsFound = Get-ChildItem -Path $variantApiDeployYamlPath -Filter "*.yaml" -Recurse
-if ($deployYamlsFound.Count -gt 0)
-{
+$testPath = Test-Path -Path $variantApiDeployYamlPath
+Write-Information "Deploy folder exists in .variant directory: $testPath"
+if ($testPath -eq $true) {
+  $deployYamlsFound = Get-ChildItem -Path $variantApiDeployYamlPath -Filter "*.yaml" -Recurse
+}
+else {
+  throw "Deploy folder does not exists"
+}
+
+if ($deployYamlsFound.Count -gt 0) {
   Set-Location ${RepositoryRoot}
   dotnet nuget add source --username "${NugetUser}" --password "${NugetToken}" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/variant-inc/index.json"
   ce dotnet nuget update source github -u "${NugetUser}" -p "${NugetToken}" --store-password-in-clear-text -s "https://nuget.pkg.github.com/variant-inc/index.json"


### PR DESCRIPTION
# Description

Adding error handling to check deploy path.

Fixes [#8](https://usxtech.atlassian.net/browse/CLOUD-1645)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```yaml
Pre reqs:
  - Create a directory structure of .variant in demo-nodes-app for example ([test/CLOUD-1645-error-handling](https://github.com/variant-inc/demo-nodejs-app/tree/test/CLOUD-1645-error-handling)

Test Case 1 [Deploy config.yaml with out deploy folder]:
- Steps
  - Make sure action octopus is pointing to error handling branch
- Result
 - Should fail with proper error message


Test Case 2 [Deploy config.yaml with deploy folder]:
- Steps
  - Make sure action octopus is pointing to error handling branch
- Results
  - See pass through this step and should not fail for missing deploy folder.


```
- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
