### PR TITLE
[CLOUD-1717] version bump

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "terragrunt-variant-apps package version"
     required: false
   task_runner_version:
-    default: "1.0.0-release0001-287"
+    default: "1.0.0-release0001-291"
     description: "cake-runner package version"
     required: false
 runs:


### PR DESCRIPTION
# Description

https://drivevariant.atlassian.net/browse/CLOUD-1717

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Sanity Testing
[Demo-python-flask-api branch](https://github.com/variant-inc/demo-python-flask-variant-api/blob/test/CLOUD-1717/.variant/deploy/base-api.yaml)
```
      - name: Lazy Action Octopus
        uses: variant-inc/actions-octopus@v3
        with:
          task_runner_version: 1.0.0-f-cloud-1717-ter0001-289
```

- [x] Sanity Testing
- No Infrastrcuture: [Octopus](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-base-api-cloud-1717/deployments/releases/0.1.0-test-cloud-1717-0001.25/deployments/Deployments-36081?activeTab=taskLog)
```
name: demo-base-api-cloud-1717
octopus:
  space: DevOps
  group: demo
tags:
  owner: CloudOps
  team: CloudOps
api:
  service:
    targetPort: 5000
```

- With infrastructure: [Octopus](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-base-api-cloud-1717/deployments/releases/0.1.0-test-cloud-1717-0001.26/deployments/Deployments-36086?activeTab=taskLog)
```
name: demo-base-api-cloud-1717
octopus:
  space: DevOps
  group: demo
tags:
  owner: CloudOps
  team: CloudOps
infrastructure:
  buckets:
    managed:
      - prefix: demo-flask-api
        reference: hw
    existing:
      - project_name: demo-python-flask-variant-api
        project_group: demo
        bucket_prefix: demo-flask-api
        reference: hw
  sns_topics:
    - name: test-topic-cloud-1717
      fifo_topic: false
      reference: hw
  postgres:
    - name: test-database-cloud-1717
      role_name: admin-cloud-1717
      extensions: ["postgis"]
      reference: test-cloud-1717
api:
  service:
    targetPort: 5000
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules