### PR TITLE
[CLOUD-1743] bumping TVA version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: master
   deploy_package_version:
-    default: 1.0.1.474
+    default: 1.0.1.475
     description: terragrunt-variant-apps package version
     required: false
   task_runner_version:


### PR DESCRIPTION
# Description

Bumping TVA to 1.0.1.475

Fixes [CLOUD-1743](https://drivevariant.atlassian.net/browse/CLOUD-1743)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
