### PR TITLE
F/cloud 1783 sonar

### DIFF
--- a/tasks.ps1
+++ b/tasks.ps1
@@ -31,6 +31,29 @@ function CommandAliasFunction {
 Set-Alias -Name ce -Value CommandAliasFunction -Scope script
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Scope = 'Function')]
+
+Write-Output "Starting Sonar check"
+if ($env:MASTER_BRANCH -eq $env:GITVERSION_BRANCHNAME){
+  $sonarCheckUrl = "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$env:SONAR_PROJECT_KEY&branch=$env:GITVERSION_BRANCHNAME"
+  $headers = @{
+      'Authorization' = 'Bearer ' + $env:SONAR_TOKEN
+      'Accept'        = 'application/json'
+  }
+  try {
+    $Response = Invoke-RestMethod -Uri $sonarCheckUrl -Headers $headers -Method GET
+    if ($Response.projectStatus -eq "OK") {
+      Write-Output "Sonnar scan quality gate passed. Continuing with the deployment."
+    } else {
+      Write-Output "Sonnar scan quality gate failed. Stopping the deployment."
+      exit 1
+    }
+  }
+  catch {
+    Write-Output "Skipping sonar check as project: $env:SONAR_PROJECT_KEY doesn't exist."
+  }
+}
+Write-Output "Sonar check done"
+
 $variantApiDeployYamlPath = [System.IO.Path]::GetFullPath((Join-Path ${RepositoryRoot} ".variant/deploy/"))
 
 if ((Test-Path -Path $variantApiDeployYamlPath) -eq $true) {

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -40,7 +40,7 @@ if ($env:INPUT_DEFAULT_BRANCH -eq $env:GITVERSION_BRANCHNAME){
   try {
     $Response = Invoke-RestMethod -Uri $sonarCheckUrl -Headers $headers -Method GET
     $Response | ConvertTo-Json
-    if ($Response.projectStatus -eq "OK") {
+    if ($Response.projectStatus.status -eq "OK") {
       Write-Output "Sonnar scan quality gate passed. Continuing with the deployment."
     } else {
       Write-Output "Sonnar scan quality gate failed. Stopping the deployment."

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -30,14 +30,12 @@ function CommandAliasFunction {
 
 Set-Alias -Name ce -Value CommandAliasFunction -Scope script
 
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Scope = 'Function')]
-
 Write-Output "Starting Sonar check"
 if ($env:INPUT_DEFAULT_BRANCH -eq $env:GITVERSION_BRANCHNAME){
   $sonarCheckUrl = "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$env:SONAR_PROJECT_KEY&branch=$env:GITVERSION_BRANCHNAME"
   $headers = @{
-      'Authorization' = 'Bearer ' + $env:SONAR_TOKEN
-      'Accept'        = 'application/json'
+    'Authorization' = 'Bearer ' + $env:SONAR_TOKEN
+    'Accept'        = 'application/json'
   }
   try {
     $Response = Invoke-RestMethod -Uri $sonarCheckUrl -Headers $headers -Method GET
@@ -54,6 +52,7 @@ if ($env:INPUT_DEFAULT_BRANCH -eq $env:GITVERSION_BRANCHNAME){
 }
 Write-Output "Sonar check done"
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Scope = 'Function')]
 $variantApiDeployYamlPath = [System.IO.Path]::GetFullPath((Join-Path ${RepositoryRoot} ".variant/deploy/"))
 
 if ((Test-Path -Path $variantApiDeployYamlPath) -eq $true) {

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -39,6 +39,7 @@ if ($env:INPUT_DEFAULT_BRANCH -eq $env:GITVERSION_BRANCHNAME){
   }
   try {
     $Response = Invoke-RestMethod -Uri $sonarCheckUrl -Headers $headers -Method GET
+    $Response | ConvertTo-Json
     if ($Response.projectStatus -eq "OK") {
       Write-Output "Sonnar scan quality gate passed. Continuing with the deployment."
     } else {

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -33,7 +33,7 @@ Set-Alias -Name ce -Value CommandAliasFunction -Scope script
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Scope = 'Function')]
 
 Write-Output "Starting Sonar check"
-if ($env:MASTER_BRANCH -eq $env:GITVERSION_BRANCHNAME){
+if ($env:INPUT_DEFAULT_BRANCH -eq $env:GITVERSION_BRANCHNAME){
   $sonarCheckUrl = "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$env:SONAR_PROJECT_KEY&branch=$env:GITVERSION_BRANCHNAME"
   $headers = @{
       'Authorization' = 'Bearer ' + $env:SONAR_TOKEN


### PR DESCRIPTION
# Description

Fail creating Octopus release for master branch if Sonar Quality gate is Failed.

Fixes [#1783](https://drivevariant.atlassian.net/browse/CLOUD-1783)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

#### Case 1: default_branch different than current branch:
Edit GH workflow file
```
- name: Lazy Action Octopus
        uses: variant-inc/actions-octopus@f/cloud-1783-sonar
```
[Actions run](https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/3360291368/jobs/5569389829#step:7:197)

#### Case: 2 Success Sonar quality gate and check: 
Edit GH workflow file
```
- name: Lazy Action Octopus
        uses: variant-inc/actions-octopus@f/cloud-1783-sonar
        with:
          default_branch: demo/luka-2
```
[Actions run](https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/3360357540/jobs/5569590121#step:7:205)

#### Case: 3 Failed Sonar quality gate:
Edit GH workflow file
```
- name: Lazy Action Octopus
        uses: variant-inc/actions-octopus@f/cloud-1783-sonar
        with:
          default_branch: demo/luka-2
```
Edit sonar-project.properties file by commenting out tests and exclusions line
```
#sonar.tests.inclusions=tests/**
#sonar.exclusions=tests/**,setup.py,docker-compose.yaml
```
Add dummy function in app code
```
def sonar_fail_pls():
    print("Sonar will this make you fail?")
```
Change Quality gate on Sonar to `All Code` from `Test Quality Gate Pass`
[Actions run](https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/3361112278/jobs/5571105866#step:7:212)

#### Case: 4 Wrong Sonar project key:
Edit GH workflow file and comment out actions-python to prevent creation of new Sonar project with set key
```
# - name: Lazy action steps
      #   id: lazy-action
      #   uses: variant-inc/actions-python@v1
      #   with:
      #     dockerfile_dir_path: "."
      #     ecr_repository: ${{ env.ECR_REPOSITORY }}
      #     test_framework: pytest
- name: Lazy Action Octopus
        uses: variant-inc/actions-octopus@f/cloud-1783-sonar
        with:
          default_branch: demo/luka-2
```
Edit sonar-project.properties file by changing project key
```
sonar.projectKey=variant-inc_demo-python-flask-variant-api3
```
[Actions run](https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/3361156280/jobs/5571205247#step:5:195)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
