### PR TITLE
CLOUD-2089: Bumping versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
     required: false
     default: master
   deploy_package_version:
-    default: 1.0.1.651
+    default: 1.0.1.652
     description: terraform-variant-apps package version
     required: false
   task_runner_version:
-    default: 2.1.2-release0001-1024
+    default: 2.1.2-release0001-1039
     description: cake-runner package version
     required: false
 runs:


### PR DESCRIPTION
# Description

Bumping versions of cake-runner and terraform-variant-apps to the latest ones for reflecting the changes for auth & Azure AD

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would
cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested these versions by using them in the demo-python-flask-api

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

