### PR TITLE
CLOUD-2104: Bumping versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
     required: false
     default: master
   deploy_package_version:
-    default: 1.0.1.652
+    default: 1.0.1.659
     description: terraform-variant-apps package version
     required: false
   task_runner_version:
-    default: 2.1.2-release0001-1039
+    default: 2.1.2-release0001-1052
     description: cake-runner package version
     required: false
 runs:


### PR DESCRIPTION
# Description

Please look into the below mentioned ticket for description

Fixes [#2104](https://usxpress.atlassian.net/browse/CLOUD-2104)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested it locally from cake. Also tested it by deploying using these changes in demo-python-flask-api. 
Octopus links of successful deployments: https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-api-sathwik/deployments/releases/0.1.0-test-cloud-2104-0001.587/deployments/Deployments-51582?activeTab=taskLog

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
