### PR TITLE
move cake-runner to az devops

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create Release in Octopus
 | parameter | description | required | default |
 | --- | --- | --- | --- |
 | deploy_package_version | terraform-variant-apps package version | `false` | 1.1.1.663 |
-| task_runner_version | cake-runner package version | `false` | 2.1.2-release0001-1130 |
+| cake_runner_version | cake-runner package version | `false` | |
 <!-- action-docs-inputs -->
 <!-- markdownlint-enable line-length -->
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,10 @@
 # Octopus GitHub Action
 
+<!-- markdownlint-disable line-length -->
 <!-- action-docs-description -->
 ## Description
 
-Create Release in Octopus
-<!-- action-docs-description -->
-
-<!-- markdownlint-disable line-length -->
-<!-- action-docs-inputs -->
-## Inputs
-
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| deploy_package_version | terraform-variant-apps package version | `false` | 1.1.1.663 |
-| cake_runner_version | cake-runner package version | `false` | |
-<!-- action-docs-inputs -->
-<!-- markdownlint-enable line-length -->
-
-<!-- action-docs-outputs -->
-
-<!-- action-docs-outputs -->
-
-<!-- action-docs-runs -->
-## Runs
-
-This action is a `composite` action.
-<!-- action-docs-runs -->
-
-## Input variables
-
-| Parameter     | Default  | Description                   | Required| Example|
-| --------------| ---------| ------------------------------| --------| -------|
-| default_branch| `master` | Directory of the solution file| false   | master |
-___
+Github Action to create release in Octopus.
 
 ## Usage
 
@@ -42,12 +14,12 @@ documentation as actions-octopus v3 should only be used in tandem with DX Workfl
 DX Workflow defines and deploys both infrastructure and applications.
 
 1. Create a deployment spec in `.variant/deploy`. Reference the
-   [DX Workflow Documentation](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Getting-Started/Tutorials/)
-   and these [examples](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/dx-requirements/#more-examples)
-   for more information.
+  [DX Workflow Documentation](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Getting-Started/Tutorials/)
+  and these [examples](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/dx-requirements/#more-examples)
+  for more information.
 
 2. Add a build step to your GitHub actions workflow yaml. More examples
-   [here](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Getting-Started/Github/Github-Actions/#examples-of-github-actions-that-the-dx-workflow-supports).
+  [here](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Getting-Started/Github/Github-Actions/#examples-of-github-actions-that-the-dx-workflow-supports).
 
 ```yaml
 - name: Lazy Action Octopus
@@ -61,6 +33,28 @@ infrastructure can migrate to v3.
 
 1. Change uses new action version v3: `variant-inc/actions-octopus@v3`
 2. Add a Variant Deploy Yaml File following the usage above.
-   Note that only certain versions of charts in lazy-helm-charts are supported
-   and may require you to update and fix breaking changes with
-   the helm release.
+  Note that only certain versions of charts in lazy-helm-charts are supported
+  and may require you to update and fix breaking changes with
+  the helm release.
+<!-- action-docs-description -->
+
+<!-- markdownlint-disable line-length -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| deploy_package_version | terraform-variant-apps package version | `false` | 1.1.1.663 |
+| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in NuGet notation. https://learn.microsoft.com/en-us/nuget/concepts/package-versioning  | `false` |  |
+<!-- action-docs-inputs -->
+<!-- markdownlint-enable line-length -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ infrastructure can migrate to v3.
 | parameter | description | required | default |
 | --- | --- | --- | --- |
 | deploy_package_version | terraform-variant-apps package version | `false` | 1.1.1.663 |
-| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in NuGet notation. [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning)  | `false` |  |
+| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` |  |
 <!-- action-docs-inputs -->
 <!-- markdownlint-enable line-length -->
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ infrastructure can migrate to v3.
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| deploy_package_version | terraform-variant-apps package version | `false` | 1.1.1.663 |
+| deploy_package_version | terraform-variant-apps package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` |  |
 | cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` |  |
 <!-- action-docs-inputs -->
 <!-- markdownlint-enable line-length -->

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ infrastructure can migrate to v3.
 | parameter | description | required | default |
 | --- | --- | --- | --- |
 | deploy_package_version | terraform-variant-apps package version | `false` | 1.1.1.663 |
-| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in NuGet notation. https://learn.microsoft.com/en-us/nuget/concepts/package-versioning  | `false` |  |
+| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in NuGet notation. [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning)  | `false` |  |
 <!-- action-docs-inputs -->
 <!-- markdownlint-enable line-length -->
 

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,9 @@ description: |
     the helm release.
 inputs:
   deploy_package_version:
-    default: 1.1.1.663
-    description: terraform-variant-apps package version
+    description: |
+      terraform-variant-apps package version
+      Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
   cake_runner_version:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: 1.1.1.663
     description: terraform-variant-apps package version
     required: false
-  task_runner_version:
+  cake_runner_version:
     description: cake-runner package version
     required: false
 runs:
@@ -28,7 +28,7 @@ runs:
       run: ${{ github.action_path }}/tasks.ps1
       env:
         INPUT_DEPLOY_PACKAGE_VERSION: ${{ inputs.deploy_package_version }}
-        TASK_RUNNER_VERSION: ${{ inputs.task_runner_version }}
+        CAKE_RUNNER_VERSION: ${{ inputs.cake_runner_version }}
         OCTOPUS_CLI_API_KEY: ${{ env.OCTOPUS_CLI_API_KEY }}
         OCTOPUS_CLI_SERVER: ${{ env.OCTOPUS_CLI_SERVER }}
     - name: Create Release Action

--- a/action.yml
+++ b/action.yml
@@ -42,8 +42,7 @@ inputs:
   cake_runner_version:
     description: |
       cake-runner package version
-      Defaults to latest release version. Can be overriden by exact version or specifying range in NuGet notation.
-      https://learn.microsoft.com/en-us/nuget/concepts/package-versioning
+      Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,6 @@ inputs:
     description: terraform-variant-apps package version
     required: false
   task_runner_version:
-    default: 2.1.2-release0001-1130
     description: cake-runner package version
     required: false
 runs:

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,49 @@
 ---
+# yamllint disable rule:line-length
 name: Lazy Octopus Action
-description: Create Release in Octopus
+description: |
+  Github Action to create release in Octopus.
+
+  ## Usage
+
+  Please reference
+  [DX Workflow](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs)
+  documentation as actions-octopus v3 should only be used in tandem with DX Workflow.
+  DX Workflow defines and deploys both infrastructure and applications.
+
+  1. Create a deployment spec in `.variant/deploy`. Reference the
+    [DX Workflow Documentation](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Getting-Started/Tutorials/)
+    and these [examples](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/dx-requirements/#more-examples)
+    for more information.
+
+  2. Add a build step to your GitHub actions workflow yaml. More examples
+    [here](https://backstage.apps.ops-drivevariant.com/docs/default/Component/dx-docs/Getting-Started/Github/Github-Actions/#examples-of-github-actions-that-the-dx-workflow-supports).
+
+  ```yaml
+  - name: Lazy Action Octopus
+    uses: variant-inc/actions-octopus@v3
+  ```
+
+  ## Migrating to v3
+
+  v3 runs CI using cake. Currently only repositories that do not deploy
+  infrastructure can migrate to v3.
+
+  1. Change uses new action version v3: `variant-inc/actions-octopus@v3`
+  2. Add a Variant Deploy Yaml File following the usage above.
+    Note that only certain versions of charts in lazy-helm-charts are supported
+    and may require you to update and fix breaking changes with
+    the helm release.
 inputs:
   deploy_package_version:
     default: 1.1.1.663
     description: terraform-variant-apps package version
     required: false
   cake_runner_version:
-    description: cake-runner package version
+    description: |
+      cake-runner package version
+      Defaults to latest release version. Can be overriden by exact version or specifying range in NuGet notation.
+      https://learn.microsoft.com/en-us/nuget/concepts/package-versioning
     required: false
 runs:
   using: composite

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -1,6 +1,17 @@
+<<<<<<< HEAD
 $NugetUser = $env:GITHUB_ACTOR
 $NugetToken = $env:GITHUB_TOKEN
 $TaskRunnerVersion = $env:TASK_RUNNER_VERSION
+=======
+[CmdLetBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessage("PSAvoidGlobalVars", '')]
+Param(
+  $NugetUser = $env:GITHUB_ACTOR,
+  $NugetToken = $env:AZ_DEVOPS_PAT,
+  $RepositoryRoot = $env:GITHUB_WORKSPACE,
+  $TaskRunnerVersion = $env:INPUT_TASK_RUNNER_VERSION
+)
+>>>>>>> 760ea12 (move cake-runner to az devops)
 
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
@@ -65,20 +76,16 @@ if ($deployYamlsFound.Count -gt 0)
     "Information"
   };
 
-  dotnet nuget add source `
-    --name cake `
-    --username "${NugetUser}" `
-    --password "${NugetToken}" `
-    --store-password-in-clear-text "https://nuget.pkg.github.com/variant-inc/index.json"
-  ce dotnet nuget update source cake `
-    -u "${NugetUser}" `
-    -p "${NugetToken}" `
-    --store-password-in-clear-text -s "https://nuget.pkg.github.com/variant-inc/index.json"
+  dotnet nuget add source --name cake --username "${NugetUser}" --password "${NugetToken}" --store-password-in-clear-text "https://pkgs.dev.azure.com/USXpress-Inc/Octopus/_packaging/Octopus/nuget/v3/index.json"
+  ce dotnet nuget update source cake -u "${NugetUser}" -p "${NugetToken}" --store-password-in-clear-text -s "https://pkgs.dev.azure.com/USXpress-Inc/Octopus/_packaging/Octopus/nuget/v3/index.json"
   ce dotnet new tool-manifest --force
 
-  ce dotnet tool install `
-    --version "${TaskRunnerVersion}" `
-    --no-cache Variant.Cake.Runner
+  if ($TaskRunnerVersion) {
+    ce dotnet tool install --version "${TaskRunnerVersion}" --no-cache Variant.Cake.Runner
+  } else {
+    ce dotnet tool install --no-cache Variant.Cake.Runner
+  }
+  $TaskRunnerVersion = (Get-Content .config/dotnet-tools.json | ConvertFrom-Json).tools."variant.cake.runner".version
   ce dotnet variant-cake-runner `
     --target CreateRelease `
     --taskRunnerVersion $TaskRunnerVersion `

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -65,7 +65,7 @@ if ($deployYamlsFound.Count -gt 0)
     "Information"
   };
 
-  [pscredential]$cred = New-Object System.Management.Automation.PSCredential ($NugetUser, ${ConvertTo-SecureString $NugetToken -AsPlainText -Force})
+  [pscredential]$cred = New-Object System.Management.Automation.PSCredential ($NugetUser, $(ConvertTo-SecureString $NugetToken -AsPlainText -Force))
   Register-PackageSource -Name "cake" -Credential $cred -Location "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json" -ProviderName "NuGet" -Trusted
   if ($env:INPUT_DEPLOY_PACKAGE_VERSION.length -eq 0){
     $env:INPUT_DEPLOY_PACKAGE_VERSION = (Find-Package -Name "terraform-variant-apps" -Source "cake" -Credential $cred -Provider "NuGet" -AllVersions -MinimumVersion 0 | Sort-Object {$_.Version} | Select-Object -Last 1).Version

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -76,8 +76,8 @@ if ($deployYamlsFound.Count -gt 0)
     "Information"
   };
 
-  dotnet nuget add source --name cake --username "${NugetUser}" --password "${NugetToken}" --store-password-in-clear-text "https://pkgs.dev.azure.com/USXpress-Inc/Octopus/_packaging/Octopus/nuget/v3/index.json"
-  ce dotnet nuget update source cake -u "${NugetUser}" -p "${NugetToken}" --store-password-in-clear-text -s "https://pkgs.dev.azure.com/USXpress-Inc/Octopus/_packaging/Octopus/nuget/v3/index.json"
+  dotnet nuget add source --name cake --username "${NugetUser}" --password "${NugetToken}" --store-password-in-clear-text "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json"
+  ce dotnet nuget update source cake -u "${NugetUser}" -p "${NugetToken}" --store-password-in-clear-text -s "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json"
   ce dotnet new tool-manifest --force
 
   if ($TaskRunnerVersion) {

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -1,5 +1,5 @@
 $NugetUser = $env:GITHUB_ACTOR
-$NugetToken = $env:GITHUB_TOKEN
+$NugetToken = $env:AZ_DEVOPS_PAT
 $CakeRunnerVersion = $env:CAKE_RUNNER_VERSION
 
 $ErrorActionPreference = "Stop"

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -65,8 +65,14 @@ if ($deployYamlsFound.Count -gt 0)
     "Information"
   };
 
+  [pscredential]$cred = New-Object System.Management.Automation.PSCredential ($NugetUser, ${ConvertTo-SecureString $NugetToken -AsPlainText -Force})
+  Register-PackageSource -Name "cake" -Credential $cred -Location "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json" -ProviderName "NuGet" -Trusted
+  if ($env:INPUT_DEPLOY_PACKAGE_VERSION.length -eq 0){
+    $env:INPUT_DEPLOY_PACKAGE_VERSION = (Find-Package -Name "terraform-variant-apps" -Source "cake" -Credential $cred -Provider "NuGet" -AllVersions -MinimumVersion 0 | Sort-Object {$_.Version} | Select-Object -Last 1).Version
+  }
+
   dotnet nuget add source --name cake --username "${NugetUser}" --password "${NugetToken}" --store-password-in-clear-text "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json"
-  ce dotnet nuget update source cake -u "${NugetUser}" -p "${NugetToken}" --store-password-in-clear-text -s "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json"
+  dotnet nuget update source cake -u "${NugetUser}" -p "${NugetToken}" --store-password-in-clear-text -s "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json"
   ce dotnet new tool-manifest --force
 
   if ($CakeRunnerVersion) {

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -1,17 +1,6 @@
-<<<<<<< HEAD
 $NugetUser = $env:GITHUB_ACTOR
 $NugetToken = $env:GITHUB_TOKEN
-$TaskRunnerVersion = $env:TASK_RUNNER_VERSION
-=======
-[CmdLetBinding()]
-[Diagnostics.CodeAnalysis.SuppressMessage("PSAvoidGlobalVars", '')]
-Param(
-  $NugetUser = $env:GITHUB_ACTOR,
-  $NugetToken = $env:AZ_DEVOPS_PAT,
-  $RepositoryRoot = $env:GITHUB_WORKSPACE,
-  $TaskRunnerVersion = $env:INPUT_TASK_RUNNER_VERSION
-)
->>>>>>> 760ea12 (move cake-runner to az devops)
+$CakeRunnerVersion = $env:CAKE_RUNNER_VERSION
 
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
@@ -80,15 +69,15 @@ if ($deployYamlsFound.Count -gt 0)
   ce dotnet nuget update source cake -u "${NugetUser}" -p "${NugetToken}" --store-password-in-clear-text -s "https://pkgs.dev.azure.com/USXpress-Inc/CloudOps/_packaging/Octopus/nuget/v3/index.json"
   ce dotnet new tool-manifest --force
 
-  if ($TaskRunnerVersion) {
-    ce dotnet tool install --version "${TaskRunnerVersion}" --no-cache Variant.Cake.Runner
+  if ($CakeRunnerVersion) {
+    ce dotnet tool install --version "${CakeRunnerVersion}" --no-cache Variant.Cake.Runner
   } else {
     ce dotnet tool install --no-cache Variant.Cake.Runner
   }
-  $TaskRunnerVersion = (Get-Content .config/dotnet-tools.json | ConvertFrom-Json).tools."variant.cake.runner".version
+  $CakeRunnerVersion = (Get-Content .config/dotnet-tools.json | ConvertFrom-Json).tools."variant.cake.runner".version
   ce dotnet variant-cake-runner `
     --target CreateRelease `
-    --taskRunnerVersion $TaskRunnerVersion `
+    --cakeRunnerVersion $CakeRunnerVersion `
     --deployYamlDirPath $variantApiDeployYamlPath `
     --logLevel $CakeLogLevel `
     --seriloglevel $SerilogLogLevel


### PR DESCRIPTION
# Description

Moving cake-runner to Azure DevOps Artifacts
Removing need to update default task_runner_version input for every update on cake-runner

**Merge together with https://github.com/variant-inc/cake-runner/pull/60**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

See https://github.com/variant-inc/cake-runner/pull/60

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
