### PR TITLE
CLOUD-2413 Cake Runner fails when custom probes are provided

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
       - name: Install pre-commit dependencies
         run: |
           # Action Docs - https://github.com/npalm/action-docs

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ infrastructure can migrate to v3.
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| deploy_package_version | terraform-variant-apps package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.4) |
-| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.4) |
+| deploy_package_version | terraform-variant-apps package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.5) |
+| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.5) |
 <!-- action-docs-inputs -->
 <!-- markdownlint-enable line-length -->
 

--- a/action.yml
+++ b/action.yml
@@ -40,13 +40,13 @@ inputs:
       terraform-variant-apps package version
       Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
-    default: '[*,1.4)'
+    default: '[*,1.5)'
   cake_runner_version:
     description: |
       cake-runner package version
       Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
-    default: '[*,1.4)'
+    default: '[*,1.5)'
 runs:
   using: composite
   steps:


### PR DESCRIPTION
# Description

Bump Version for the fix related to CLOUD-2413

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would
cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/vibin-test/deployments/releases/0.1.0-f-vd0115.712/deployments/Deployments-59089

- [x] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
