### PR TITLE
CLOUD-2408 Update Lazy-Helm Charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ infrastructure can migrate to v3.
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| deploy_package_version | terraform-variant-apps package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.5) |
-| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.5) |
+| deploy_package_version | terraform-variant-apps package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.6) |
+| cake_runner_version | cake-runner package version Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).  | `false` | [*,1.6) |
 | deploy_yaml_dir | Defaults to `.variant/deploy` for backwards compatibility. This is the place where the YAML files for DX are located.  | `false` | .variant/deploy |
 <!-- action-docs-inputs -->
 <!-- markdownlint-enable line-length -->

--- a/action.yml
+++ b/action.yml
@@ -40,13 +40,13 @@ inputs:
       terraform-variant-apps package version
       Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
-    default: '[*,1.5)'
+    default: '[*,1.6)'
   cake_runner_version:
     description: |
       cake-runner package version
       Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
-    default: '[*,1.5)'
+    default: '[*,1.6)'
   deploy_yaml_dir:
     description: |
       Defaults to `.variant/deploy` for backwards compatibility.


### PR DESCRIPTION
# Description

- supports oci helm-charts
- adds new routes chart
- add preStep, postStep to Octopus
- allows different directory for location of deployYaml


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would
cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
