### PR TITLE
feat: cloud-2662 remove group from state path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
       mage-runner package version
       Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
-    default: '[*,1.6)'
+    default: '[*,1.7)'
   deploy_yaml_dir:
     description: |
       Defaults to `.variant/deploy` for backwards compatibility.


### PR DESCRIPTION
# Description

Update mage runner version to remove Octopus group from state file path.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would
cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

https://github.com/variant-inc/mage-runner/pull/59

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
