### PR TITLE
feat!: add helm schema validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: shellcheck
       - id: shfmt
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
@@ -30,7 +30,7 @@ repos:
       - id: yamlfmt
         args: [--mapping, '2', --sequence, '4', --offset, '2']
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.37.0
     hooks:
       - id: yamllint
         args: [--format, parsable, --strict]

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
       terraform-variant-apps package version
       Defaults to latest release version. Can be overriden by exact version or specifying range in [NuGet notation](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning).
     required: false
-    default: '[*,3.15)'
+    default: '[*,4.1)'
   mage_runner_version:
     description: |
       mage-runner package version


### PR DESCRIPTION
BREAKING CHANGE: major version of helm-charts update for schema validation

# Description

Part of enabling helm schema validation, since it is breaking change for existing apps (ones with extra things in deployment YAML) we're bumping major version allowing developers to upgrade at their own time.

Related PR: https://github.com/variant-inc/helm-charts/pull/48

Fixes <https://usxpress.atlassian.net/browse/CLOUD-2623>

Child tickets:
<https://usxpress.atlassian.net/browse/CLOUD-2628>
<https://usxpress.atlassian.net/browse/CLOUD-2627>
<https://usxpress.atlassian.net/browse/CLOUD-2626>
<https://usxpress.atlassian.net/browse/CLOUD-2625>
<https://usxpress.atlassian.net/browse/CLOUD-2624>

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would
cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Described in related [PR](https://github.com/variant-inc/helm-charts/pull/48). 

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
